### PR TITLE
Remove experimental worker logs setting

### DIFF
--- a/schemas/settings.schema.json
+++ b/schemas/settings.schema.json
@@ -319,15 +319,6 @@
                     "title": "Warn",
                     "type": "boolean"
                 },
-                "worker_logging_to_api_enabled": {
-                    "default": false,
-                    "description": "Enables the logging of worker logs to Prefect Cloud.",
-                    "supported_environment_variables": [
-                        "PREFECT_EXPERIMENTS_WORKER_LOGGING_TO_API_ENABLED"
-                    ],
-                    "title": "Worker Logging To Api Enabled",
-                    "type": "boolean"
-                },
                 "telemetry_enabled": {
                     "default": false,
                     "description": "Enables sending telemetry to Prefect Cloud.",

--- a/src/prefect/settings/models/experiments.py
+++ b/src/prefect/settings/models/experiments.py
@@ -18,11 +18,6 @@ class ExperimentsSettings(PrefectBaseSettings):
         ),
     )
 
-    worker_logging_to_api_enabled: bool = Field(
-        default=False,
-        description="Enables the logging of worker logs to Prefect Cloud.",
-    )
-
     telemetry_enabled: bool = Field(
         default=False,
         description="Enables sending telemetry to Prefect Cloud.",

--- a/src/prefect/utilities/urls.py
+++ b/src/prefect/utilities/urls.py
@@ -3,7 +3,7 @@ import ipaddress
 import socket
 import urllib.parse
 from string import Formatter
-from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Union
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -135,7 +135,7 @@ def url_for(
     obj_id: Optional[Union[str, UUID]] = None,
     url_type: URLType = "ui",
     default_base_url: Optional[str] = None,
-    **additional_format_kwargs: Optional[Dict[str, Any]],
+    **additional_format_kwargs: Any,
 ) -> Optional[str]:
     """
     Returns the URL for a Prefect object.

--- a/src/prefect/workers/base.py
+++ b/src/prefect/workers/base.py
@@ -821,14 +821,14 @@ class BaseWorker(abc.ABC):
             self._logger = get_worker_logger(self)
 
         self._logger.debug(
-            f"Worker synchronized with the Prefect API server. Remote ID: {self.backend_id}"
+            "Worker synchronized with the Prefect API server. "
+            + (f"Remote ID: {self.backend_id}" if self.backend_id else "")
         )
 
     def _should_get_worker_id(self):
         """Determines if the worker should request an ID from the API server."""
         return (
-            get_current_settings().experiments.worker_logging_to_api_enabled
-            and self._client
+            self._client
             and self._client.server_type == ServerType.CLOUD
             and self.backend_id is None
         )
@@ -886,10 +886,7 @@ class BaseWorker(abc.ABC):
                 run_logger.info(
                     f"Worker '{self.name}' submitting flow run '{flow_run.id}'"
                 )
-                if (
-                    get_current_settings().experiments.worker_logging_to_api_enabled
-                    and self.backend_id
-                ):
+                if self.backend_id:
                     try:
                         worker_url = url_for(
                             "worker",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -231,7 +231,6 @@ SUPPORTED_SETTINGS = {
     "PREFECT_EXPERIMENTAL_WARN": {"test_value": True, "legacy": True},
     "PREFECT_EXPERIMENTS_TELEMETRY_ENABLED": {"test_value": False},
     "PREFECT_EXPERIMENTS_WARN": {"test_value": True},
-    "PREFECT_EXPERIMENTS_WORKER_LOGGING_TO_API_ENABLED": {"test_value": False},
     "PREFECT_FLOW_DEFAULT_RETRIES": {"test_value": 10, "legacy": True},
     "PREFECT_FLOWS_DEFAULT_RETRIES": {"test_value": 10},
     "PREFECT_FLOW_DEFAULT_RETRY_DELAY_SECONDS": {"test_value": 10, "legacy": True},

--- a/tests/workers/test_base_worker.py
+++ b/tests/workers/test_base_worker.py
@@ -28,7 +28,6 @@ from prefect.server.schemas.core import Deployment, Flow, WorkPool
 from prefect.server.schemas.responses import DeploymentResponse
 from prefect.settings import (
     PREFECT_API_URL,
-    PREFECT_EXPERIMENTS_WORKER_LOGGING_TO_API_ENABLED,
     PREFECT_TEST_MODE,
     PREFECT_WORKER_PREFETCH_SECONDS,
     get_current_settings,
@@ -83,14 +82,6 @@ async def variables(prefect_client: PrefectClient):
 @pytest.fixture
 def no_api_url():
     with temporary_settings(updates={PREFECT_TEST_MODE: False, PREFECT_API_URL: None}):
-        yield
-
-
-@pytest.fixture
-def experimental_logging_enabled():
-    with temporary_settings(
-        updates={PREFECT_EXPERIMENTS_WORKER_LOGGING_TO_API_ENABLED: True}
-    ):
         yield
 
 
@@ -197,7 +188,7 @@ async def test_worker_sends_heartbeat_gets_id(respx_mock):
         assert worker.backend_id == test_worker_id
 
 
-async def test_worker_sends_heartbeat_only_gets_id_once(experimental_logging_enabled):
+async def test_worker_sends_heartbeat_only_gets_id_once():
     async with WorkerTestImpl(name="test", work_pool_name="test-work-pool") as worker:
         worker._client.server_type = ServerType.CLOUD
         mock = AsyncMock(return_value="test")
@@ -1567,7 +1558,6 @@ async def test_get_flow_run_logger_with_worker_id_set(
     prefect_client: PrefectClient,
     worker_deployment_wq1,
     work_pool,
-    experimental_logging_enabled,
 ):
     flow_run = await prefect_client.create_flow_run_from_deployment(
         worker_deployment_wq1.id
@@ -1883,7 +1873,7 @@ async def test_env_merge_logic_is_deep(
 
 class TestBaseWorkerHeartbeat:
     async def test_worker_heartbeat_sends_integrations(
-        self, work_pool, hosted_api_server, experimental_logging_enabled
+        self, work_pool, hosted_api_server
     ):
         async with WorkerTestImpl(work_pool_name=work_pool.name) as worker:
             await worker.start(run_once=True)
@@ -1926,7 +1916,7 @@ class TestBaseWorkerHeartbeat:
             assert worker._worker_metadata_sent
 
     async def test_custom_worker_can_send_arbitrary_metadata(
-        self, work_pool, hosted_api_server, experimental_logging_enabled
+        self, work_pool, hosted_api_server
     ):
         class CustomWorker(BaseWorker):
             type: str = "test-custom-metadata"


### PR DESCRIPTION
Worker logs are no longer experimental, so this PR removes references to the setting. We still want to avoid sending worker logs to open-source API servers until they support worker logs, though, so we use the existence of a backend_id on worker logs as a proxy for whether or not the worker is connected to Cloud. (Only workers connected to Cloud emit logs with worker IDs attached.)

Checklist
 This pull request references any related issue by including "closes <link to issue>"
If no issue exists and your change is not a small fix, please [create an issue](https://github.com/PrefectHQ/prefect/issues/new/choose) first.
 If this pull request adds new functionality, it includes unit tests that cover the changes
 If this pull request removes docs files, it includes redirect settings in mint.json.
 If this pull request adds functions or classes, it includes helpful docstrings.